### PR TITLE
camera: Disable extra HDR frame on QCOM_HARDWARE

### DIFF
--- a/camera/CameraParameters.cpp
+++ b/camera/CameraParameters.cpp
@@ -595,6 +595,14 @@ void CameraParameters::set(const char *key, const char *value)
         //XXX ALOGE("Value \"%s\"contains invalid character (= or ;)", value);
         return;
     }
+#ifdef QCOM_HARDWARE
+    // qcom cameras default to delivering an extra zero-exposure frame on HDR.
+    // The android SDK only wants one frame, so disable this unless the app
+    // explicitly asks for it
+    if (!get("hdr-need-1x")) {
+        mMap.replaceValueFor(String8("hdr-need-1x"), String8("false"));
+    }
+#endif
 
     mMap.replaceValueFor(String8(key), String8(value));
 }


### PR DESCRIPTION
Qualcomm camera HALs default to adding an extra zero-exposure frame
to HDR snapshots; this is breaking third-party apps, and we don't
use it in system-bundled apps, so disable it unless explicitly
requested by the client

Change-Id: Iecb868c5c344d972de7f36dc1bd9cc9fdbabaf4e
