### PR TITLE
MediaExtractor: Add more skip conditions for the second-pass extractors

### DIFF
--- a/media/libstagefright/MediaExtractor.cpp
+++ b/media/libstagefright/MediaExtractor.cpp
@@ -151,7 +151,9 @@ retry:
 
     if (ret != NULL) {
 
-        if (!secondPass && ( ret->countTracks() == 0 ||
+        if (!(!strcasecmp(mime, MEDIA_MIMETYPE_CONTAINER_MPEG4) &&
+                (source->flags() & DataSource::kIsCachingDataSource)) &&
+                    !isDrm && !secondPass && ( ret->countTracks() == 0 ||
                     (!strncasecmp("video/", mime, 6) && ret->countTracks() < 2) ) ) {
             secondPass = true;
             goto retry;


### PR DESCRIPTION
If the stream's container is opaque (DRM) or a known skip condition
(cached-source MPEG4), don't push it through the deep scanner

Change-Id: Ia9d60180b5d177714d206fc7dc94da93b37a048e
