### PR TITLE
libstagefright: getHFRRatio should return 1 by default

### DIFF
--- a/media/libstagefright/ExtendedUtils.cpp
+++ b/media/libstagefright/ExtendedUtils.cpp
@@ -855,7 +855,7 @@ void ExtendedUtils::HFR::copyHFRParams(
 
 int32_t ExtendedUtils::HFR::getHFRRatio(
         const sp<MetaData> &meta) {
-        return 0;
+    return 1;
 }
 
 bool ExtendedUtils::ShellProp::isAudioDisabled(bool isEncoder) {

--- a/media/libstagefright/MPEG4Writer.cpp
+++ b/media/libstagefright/MPEG4Writer.cpp
@@ -1766,9 +1766,6 @@ status_t MPEG4Writer::Track::start(MetaData *params) {
     pthread_attr_destroy(&attr);
 
     mHFRRatio = ExtendedUtils::HFR::getHFRRatio(mMeta);
-    // Workaround until HFR is fully functional
-    if (!mHFRRatio)
-	mHFRRatio = 1;
 
     return OK;
 }


### PR DESCRIPTION
This fixes camera crashes from divide-by-zero. Also, replaced the
workaround introduced in 1b7ac643d2 by a proper fix.

On ENABLE_AV_ENHANCEMENTS path, getHFRRatio returns 1 when 0 is
detected, thus the default value should be 1 not 0. (1 will turn
all multiplication and division into no-op.)

Change-Id: I5020f461011d5903a5d9bea910e11a4af9948e7f
