### PR TITLE
Revert "libstagefright: set frame packing from codec config"

### DIFF
--- a/media/libstagefright/ExtendedCodec.cpp
+++ b/media/libstagefright/ExtendedCodec.cpp
@@ -551,9 +551,6 @@ void ExtendedCodec::configureVideoDecoder(
         return;
     }
 
-    // set frame packing
-    configureFramePackingFormat(msg, OMXhandle, nodeID, componentName);
-
     setDIVXFormat(msg, mime, OMXhandle, nodeID, kPortIndexOutput);
     AString fileFormat;
     const char *fileFormatCStr = NULL;

--- a/media/libstagefright/OMXCodec.cpp
+++ b/media/libstagefright/OMXCodec.cpp
@@ -913,6 +913,8 @@ status_t OMXCodec::configureCodec(const sp<MetaData> &meta) {
             }
 
 #ifdef QCOM_HARDWARE
+            ExtendedCodec::configureFramePackingFormat(
+                    meta, mOMX, mNode, mComponentName);
             ExtendedCodec::enableSmoothStreaming(
                     mOMX, mNode, &mInSmoothStreamingMode, mComponentName);
 #endif


### PR DESCRIPTION
- With Venus 1.6, this patch causes the decoder to freeze
  during a new CTS case. Since we aren't using frame packing
  anyway, revert this.

This reverts commit 8356ac84fa349554006dfb6696365794a7d3a204.

Change-Id: I661c84727976aab8a81824279ee1a2fefdd5f8a3
