### PR TITLE
MediaPlayerFactory: remove media.stagefright.use-awesome

### DIFF
--- a/media/libmediaplayerservice/MediaPlayerFactory.cpp
+++ b/media/libmediaplayerservice/MediaPlayerFactory.cpp
@@ -63,11 +63,6 @@ status_t MediaPlayerFactory::registerFactory_l(IFactory* factory,
 
 static player_type getDefaultPlayerType() {
     char value[PROPERTY_VALUE_MAX];
-    if (property_get("media.stagefright.use-awesome", value, NULL)
-            && (!strcmp("1", value) || !strcasecmp("true", value))) {
-        return STAGEFRIGHT_PLAYER;
-    }
-
     // TODO: remove this EXPERIMENTAL developer settings property
     if (property_get("persist.sys.media.use-awesome", value, NULL)
             && !strcasecmp("true", value)) {


### PR DESCRIPTION
- persist.sys.media.use-awesome gets set in dev settings and can
  inadvertently override media.stagefright.use-awesome

Change-Id: I5ffe24f912e7a9e344b31f16f086f898ba663e9c
