### PR TITLE
audioflinger: refresh fast track underrun state upon start

### DIFF
--- a/services/audioflinger/Tracks.cpp
+++ b/services/audioflinger/Tracks.cpp
@@ -692,6 +692,11 @@ status_t AudioFlinger::PlaybackThread::Track::start(AudioSystem::sync_event_t ev
         }
 
         PlaybackThread *playbackThread = (PlaybackThread *)thread.get();
+        if (isFastTrack()) {
+            // refresh fast track underruns upon start
+            // it's essential given the same track will be recycled.
+            mObservedUnderruns = playbackThread->getFastTrackUnderruns(mFastIndex);
+        }
         status = playbackThread->addTrack_l(this);
         if (status == INVALID_OPERATION || status == PERMISSION_DENIED) {
             triggerEvents(AudioSystem::SYNC_EVENT_PRESENTATION_COMPLETE);


### PR DESCRIPTION
False underrun is detected when starting recycled fast tracks, which
leads to continuous fatal assertion failures and even AP reboot.

Track's last mObservedUnderruns isn't updated one at previous stop()
call. Hence, when we start the same track again, we should synchronize
it to the latest state instead of relying on stale one.

Change-Id: Ia003a49c6896dba965798c062c98b8c367ef8369
CRs-Fixed: 803389
